### PR TITLE
Stream arrow records from DuckDB

### DIFF
--- a/arrow.go
+++ b/arrow.go
@@ -42,7 +42,7 @@ func NewArrowQueryFromDb(ctx context.Context, db *sql.DB) (*ArrowQuery, error) {
 	return &ArrowQuery{db: db}, nil
 }
 
-func (aq *ArrowQuery) QueryContext(ctx context.Context, query string, ch chan arrow.Record) error {
+func (aq *ArrowQuery) QueryContext(ctx context.Context, query string, ch chan<- arrow.Record) error {
 	sqlConn, err := aq.db.Conn(ctx)
 	if err != nil {
 		return err

--- a/arrow.go
+++ b/arrow.go
@@ -42,11 +42,10 @@ func NewArrowQueryFromDb(ctx context.Context, db *sql.DB) (*ArrowQuery, error) {
 	return &ArrowQuery{db: db}, nil
 }
 
-func (aq *ArrowQuery) QueryContext(ctx context.Context, query string) ([]arrow.Record, error) {
-	var results []arrow.Record
+func (aq *ArrowQuery) QueryContext(ctx context.Context, query string, ch chan arrow.Record) error {
 	sqlConn, err := aq.db.Conn(ctx)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	defer sqlConn.Close()
 	err = sqlConn.Raw(func(driverConn any) error {
@@ -57,10 +56,11 @@ func (aq *ArrowQuery) QueryContext(ctx context.Context, query string) ([]arrow.R
 		if dbConn.closed {
 			return fmt.Errorf("database/sql/driver: misuse of duckdb driver: ArrowQuery after Close")
 		}
+
 		var err error
-		results, err = dbConn.QueryArrowContext(ctx, query)
+		err = dbConn.QueryArrowContext(ctx, query, ch)
 		return err
 	})
 
-	return results, err
+	return err
 }

--- a/connection.go
+++ b/connection.go
@@ -33,7 +33,7 @@ func (c *conn) CheckNamedValue(nv *driver.NamedValue) error {
 	return driver.ErrSkip
 }
 
-func (c *conn) QueryArrowContext(ctx context.Context, query string, ch chan arrow.Record) error {
+func (c *conn) QueryArrowContext(ctx context.Context, query string, ch chan<- arrow.Record) error {
 	defer close(ch)
 
 	cquery := C.CString(query)

--- a/duckdb_test.go
+++ b/duckdb_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/apache/arrow/go/v12/arrow"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -738,13 +739,25 @@ func TestArrow(t *testing.T) {
 	arrowQuery, err := NewArrowQueryFromDb(context.Background(), db)
 	require.NoError(t, err)
 
-	records, err := arrowQuery.QueryContext(context.Background(), `SELECT 1`)
-	require.NoError(t, err)
+	ch := make(chan arrow.Record)
+	var records []arrow.Record
+	var qErr error
+	go func() {
+		qErr = arrowQuery.QueryContext(context.Background(), `SELECT 1`, ch)
+	}()
+
+	for record := range ch {
+		records = append(records, record)
+	}
+
 	defer func() {
 		for _, record := range records {
 			record.Release()
 		}
 	}()
+
+	require.NoError(t, qErr)
+	require.Equal(t, 1, len(records))
 	require.Equal(t, int64(1), records[0].NumRows())
 }
 
@@ -759,13 +772,16 @@ func BenchmarkArrow(b *testing.B) {
 
 	fmt.Println("Running benchmark")
 	b.ResetTimer()
+	var qErr error
 	for i := 0; i < b.N; i++ {
 		fmt.Printf("Running iteration %d\n", i)
-		records, err := arrowQuery.QueryContext(context.Background(), `SELECT 1`)
-		require.NoError(b, err)
-		for _, record := range records {
-			record.Release()
-		}
+		ch := make(chan arrow.Record, 1)
+		go func() {
+			qErr = arrowQuery.QueryContext(context.Background(), `SELECT 1`, ch)
+		}()
+		record := <-ch
+		require.NoError(b, qErr)
+		record.Release()
 	}
 }
 
@@ -780,13 +796,24 @@ func TestMultipleArrowRecords(t *testing.T) {
 	arrowQuery, err := NewArrowQueryFromDb(context.Background(), db)
 	require.NoError(t, err)
 
-	records, err := arrowQuery.QueryContext(context.Background(), `SELECT i FROM integers ORDER BY i ASC`)
-	require.NoError(t, err)
+	ch := make(chan arrow.Record)
+	var records []arrow.Record
+	var qErr error
+	go func() {
+		qErr = arrowQuery.QueryContext(context.Background(), `SELECT i FROM integers ORDER BY i ASC`, ch)
+	}()
+
+	for record := range ch {
+		records = append(records, record)
+	}
+
 	defer func() {
 		for _, record := range records {
 			record.Release()
 		}
 	}()
+
+	require.NoError(t, qErr)
 	require.Greater(t, len(records), 1)
 	require.Greater(t, records[0].NumRows(), int64(1))
 }
@@ -799,15 +826,25 @@ func TestEmptyArrow(t *testing.T) {
 	arrowQuery, err := NewArrowQueryFromDb(context.Background(), db)
 	require.NoError(t, err)
 
-	records, err := arrowQuery.QueryContext(context.Background(), `SELECT 1 WHERE 1 = 0`)
-	require.NoError(t, err)
+	ch := make(chan arrow.Record)
+	var records []arrow.Record
+	var qErr error
+	go func() {
+		qErr = arrowQuery.QueryContext(context.Background(), `SELECT 1 WHERE 1 = 0`, ch)
+	}()
+
+	for record := range ch {
+		records = append(records, record)
+	}
+
 	defer func() {
 		for _, record := range records {
 			record.Release()
 		}
 	}()
+
+	require.NoError(t, qErr)
 	require.Equal(t, 1, len(records))
-	require.Equal(t, int64(0), records[0].NumRows())
 }
 
 func TestTypeNamesAndScanTypes(t *testing.T) {

--- a/duckdb_test.go
+++ b/duckdb_test.go
@@ -742,9 +742,9 @@ func TestArrow(t *testing.T) {
 	ch := make(chan arrow.Record)
 	var records []arrow.Record
 	var qErr error
-	go func() {
-		qErr = arrowQuery.QueryContext(context.Background(), `SELECT 1`, ch)
-	}()
+	go func(err error) {
+		err = arrowQuery.QueryContext(context.Background(), `SELECT 1`, ch)
+	}(qErr)
 
 	for record := range ch {
 		records = append(records, record)
@@ -776,9 +776,9 @@ func BenchmarkArrow(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		fmt.Printf("Running iteration %d\n", i)
 		ch := make(chan arrow.Record, 1)
-		go func() {
-			qErr = arrowQuery.QueryContext(context.Background(), `SELECT 1`, ch)
-		}()
+		go func(err error) {
+			err = arrowQuery.QueryContext(context.Background(), `SELECT 1`, ch)
+		}(qErr)
 		record := <-ch
 		require.NoError(b, qErr)
 		record.Release()
@@ -799,9 +799,9 @@ func TestMultipleArrowRecords(t *testing.T) {
 	ch := make(chan arrow.Record)
 	var records []arrow.Record
 	var qErr error
-	go func() {
-		qErr = arrowQuery.QueryContext(context.Background(), `SELECT i FROM integers ORDER BY i ASC`, ch)
-	}()
+	go func(err error) {
+		err = arrowQuery.QueryContext(context.Background(), `SELECT i FROM integers ORDER BY i ASC`, ch)
+	}(qErr)
 
 	for record := range ch {
 		records = append(records, record)
@@ -829,9 +829,9 @@ func TestEmptyArrow(t *testing.T) {
 	ch := make(chan arrow.Record)
 	var records []arrow.Record
 	var qErr error
-	go func() {
-		qErr = arrowQuery.QueryContext(context.Background(), `SELECT 1 WHERE 1 = 0`, ch)
-	}()
+	go func(err error) {
+		err = arrowQuery.QueryContext(context.Background(), `SELECT 1 WHERE 1 = 0`, ch)
+	}(qErr)
 
 	for record := range ch {
 		records = append(records, record)


### PR DESCRIPTION
#### Description

Instead of obtaining all arrow records for a given query before returning to the caller, accept a channel as input and push records to the channel one-by-one. This should enable streaming data all the way from persistent storage (parquet files on disk) to the flight client as arrow records, reducing the memory footprint on the server side for any given query.

The current solution will wait for the caller to read records from the channel before producing more records.